### PR TITLE
Update GraphQL Specification card to remove fees

### DIFF
--- a/layouts/_default/join.html
+++ b/layouts/_default/join.html
@@ -47,21 +47,12 @@
               GraphQL Specification Membership
             </h2>
 
-            <h4>
-              General Member
-            </h4>
+            <h4>Member</h4>
 
             <p>
-              See Fee Scale
+              Free; there are no fees to participate in GraphQL Specification development.
             </p>
 
-            <h4>
-              Associate Member
-            </h4>
-
-            <strong>
-              $0 **
-            </strong>
           </div>
         </div>
       </div>
@@ -174,7 +165,7 @@
               </p>
     
               <p>
-                (project only)
+                (project only, no cost)
               </p>
             </div>
           </div>


### PR DESCRIPTION
Looks like this may have been a copy/paste.  Changing the card to clarify that
there are no fees associated with Specification membership.

Signed-off-by: Brian Warner <brian@bdwarner.com>