### PR TITLE
Update instructions to include Bulma dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ This site is built using [Hugo](https://gohugo.io) and hosted on [Netlify](https
 
 ## Running the site locally {#running}
 
-To run the site locally, [install Hugo](https://gohugo.io/getting-started/installing/) and run:
+To run the site locally, you must first set it up:
+
+1. [install Hugo](https://gohugo.io/getting-started/installing/)
+1. Download [Bulma](https://bulma.io), extract the zip, rename it to `bulma`, and move it into the base directory
+
+Now you can launch a development web server:
 
 ```shell
 make serve

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This site is built using [Hugo](https://gohugo.io) and hosted on [Netlify](https
 To run the site locally, you must first set it up:
 
 1. [install Hugo](https://gohugo.io/getting-started/installing/)
-1. Download [Bulma](https://bulma.io), extract the zip, rename it to `bulma`, and move it into the base directory
+1. Install [Yarn](https://classic.yarnpkg.com/en/docs/getting-started), and run `yarn` to install dependencies
 
 Now you can launch a development web server:
 


### PR DESCRIPTION
When installing from scratch, `make serve` fails if it can't find the required Bulma files.

@lucperkins - I assume there's a reason it's not packaged with the repo.  Should I also add `burma` to `.gitignore` so it doesn't get accidentally added and pushed?

Signed-off-by: Brian Warner <brian@bdwarner.com>