### PR TITLE
Change base URL from graphql.dev to foundation.graphql.org

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://graphql.dev"
+baseURL = "https://foundation.graphql.org"
 languageCode = "en-us"
 title = "The GraphQL Foundation"
 disableKinds = ["taxonomy", "taxonomyTerm"]


### PR DESCRIPTION
The was potentially creating a redirect loop, leading to failures on aliased pages.

Signed-off-by: Brian Warner <brian@bdwarner.com>