### PR TITLE
refer to graphiql@2 more specifically

### DIFF
--- a/content/news/graphiql-graphql-playground.md
+++ b/content/news/graphiql-graphql-playground.md
@@ -49,7 +49,7 @@ In the interest of parity, we will keep a lot of the same features, whether by i
 
 ## New Features
 
-These new features will come with the new GraphiQL stable, for free!
+These new features will come with the new `graphql@2.0.0`:
 
 - vscode style command palette (via `monaco-editor`)
 - jump to fragment or other type definitions


### PR DESCRIPTION
just to make it clear, since `graphiql@1.0.0` will not contain plugins